### PR TITLE
refactor(PaymentInstallmentBusinessLogic): replace deprecated ROUND_H…

### DIFF
--- a/src/main/java/com/app/panama_trips/persistence/entity/PaymentInstallmentBusinessLogic.java
+++ b/src/main/java/com/app/panama_trips/persistence/entity/PaymentInstallmentBusinessLogic.java
@@ -1,6 +1,7 @@
 package com.app.panama_trips.persistence.entity;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 
@@ -63,7 +64,7 @@ public class PaymentInstallmentBusinessLogic {
         // 5% late fee per month (30 days)
         BigDecimal monthlyRate = PaymentInstallmentConstants.LATE_FEE_MONTHLY_RATE;
         BigDecimal dailyRate = monthlyRate.divide(new BigDecimal(PaymentInstallmentConstants.DAYS_PER_MONTH), 4,
-                BigDecimal.ROUND_HALF_UP);
+                RoundingMode.HALF_UP);
 
         return originalAmount.multiply(dailyRate).multiply(new BigDecimal(daysOverdue));
     }


### PR DESCRIPTION
This pull request makes a minor update to the `PaymentInstallmentBusinessLogic` class, replacing the deprecated `BigDecimal.ROUND_HALF_UP` constant with the more modern `RoundingMode.HALF_UP` enum. This change improves code clarity and future-proofs the rounding logic in the late fee calculation.

- Refactored rounding mode usage in `calculateLateFee` to use `RoundingMode.HALF_UP` instead of the deprecated `BigDecimal.ROUND_HALF_UP` constant for dividing the monthly rate by days per month. [[1]](diffhunk://#diff-78a301c0d2179352c360c64210b36582e65383360e251cb337cc0ad40e01e914R4) [[2]](diffhunk://#diff-78a301c0d2179352c360c64210b36582e65383360e251cb337cc0ad40e01e914L66-R67)…ALF_UP with RoundingMode.HALF_UP